### PR TITLE
Modify linked list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ desktop.ini
 *.bak
 *.old
 
+# === .json ===
+*.json
+

--- a/src/entities/DoublyLinkedList.cpp
+++ b/src/entities/DoublyLinkedList.cpp
@@ -12,13 +12,13 @@ using namespace std;
  * @param data The pointer to the Transaction object
  * @param index The current size of the linked list. This acts as the index for the node (since no deletion is involved).
  */
-Node::Node(Transaction* data, const int index) {
+Node::Node(const Transaction* data, const int index) {
 
     // First check if a valid object is passed into the method
     if (data == nullptr) throw invalid_argument("Data cannot be null.");
 
     // Initialize variables
-    this -> transactionObject = data;
+    this -> transactionObject = const_cast<Transaction*>(data);
     this -> previousNode = nullptr;
     this -> nextNode = nullptr;
     this -> indexInList = index;
@@ -98,7 +98,7 @@ void DoublyLinkedList::setTailNode(Node* tailNode) {
  * @param node The node that will be placed after the new node
  * @param data The Transaction object
  */
-void DoublyLinkedList::insertBefore(Node* node, Transaction* data) {
+void DoublyLinkedList::insertBefore(Node* node, const Transaction* data) {
 
     // Overall idea: Three nodes have to be set up. The specified node, the previous node of the specified node, and the new node.
 
@@ -137,7 +137,7 @@ void DoublyLinkedList::insertBefore(Node* node, Transaction* data) {
  * The method to insert the Transaction object into the end of linked list.
  * @param data The Transaction object to be added.
  */
-void DoublyLinkedList::insertAtEnd(Transaction* data) {
+void DoublyLinkedList::insertAtEnd(const Transaction* data) {
 
     // First create a node for the data
     const auto newNode = new Node(data, ++size);

--- a/src/entities/DoublyLinkedList.cpp
+++ b/src/entities/DoublyLinkedList.cpp
@@ -18,7 +18,7 @@ Node::Node(const Transaction* data, const int index) {
     if (data == nullptr) throw invalid_argument("Data cannot be null.");
 
     // Initialize variables
-    this -> transactionObject = *data;
+    this -> transactionObject = const_cast<Transaction*>(data);
     this -> previousNode = nullptr;
     this -> nextNode = nullptr;
     this -> indexInList = index;
@@ -56,8 +56,8 @@ DoublyLinkedList::DoublyLinkedList(const DoublyLinkedList& list): headNode(nullp
     while (current != nullptr) {
 
         // Add each transaction to the end of the list
-        this -> insertAtEnd(&current -> transactionObject);
-        current = current->nextNode;
+        this -> insertAtEnd(current -> transactionObject);
+        current = current -> nextNode;
     }
 }
 
@@ -113,7 +113,7 @@ void DoublyLinkedList::insertBefore(Node* node, const Transaction* data) {
 
     // Set up the new node
     newNode -> nextNode = node;
-    newNode -> previousNode = node -> previousNode;
+    newNode -> previousNode = node->previousNode;
 
     // Handle the node before the specified node. Special case if the node is head node
     if (node -> previousNode == nullptr) headNode = newNode;
@@ -184,11 +184,11 @@ void DoublyLinkedList::printContents() const {
 
         // Print details
         cout << "[Node at position " << currentNode -> indexInList << "]" << endl;
-        cout << "  ID        : " << currentNode -> transactionObject.transactionId << endl;
-        cout << "  Amount    : " << currentNode -> transactionObject.amount << endl;
-        cout << "  Type      : " << currentNode -> transactionObject.transactionType << endl;
-        cout << "  Channel   : " << currentNode -> transactionObject.paymentChannel << endl;
-        cout << "  Timestamp : " << currentNode -> transactionObject.timestamp << endl;
+        cout << "  ID        : " << currentNode -> transactionObject -> transactionId << endl;
+        cout << "  Amount    : " << currentNode -> transactionObject -> amount << endl;
+        cout << "  Type      : " << currentNode -> transactionObject -> transactionType << endl;
+        cout << "  Channel   : " << currentNode -> transactionObject -> paymentChannel << endl;
+        cout << "  Timestamp : " << currentNode -> transactionObject -> timestamp << endl;
         cout << "-----------------------------" << endl;
 
         // Move to the next node

--- a/src/entities/DoublyLinkedList.cpp
+++ b/src/entities/DoublyLinkedList.cpp
@@ -18,7 +18,7 @@ Node::Node(const Transaction* data, const int index) {
     if (data == nullptr) throw invalid_argument("Data cannot be null.");
 
     // Initialize variables
-    this -> transactionObject = data;
+    this -> transactionObject = const_cast<Transaction*>(data);
     this -> previousNode = nullptr;
     this -> nextNode = nullptr;
     this -> indexInList = index;

--- a/src/entities/DoublyLinkedList.cpp
+++ b/src/entities/DoublyLinkedList.cpp
@@ -189,6 +189,7 @@ void DoublyLinkedList::printContents() const {
         cout << "  Type      : " << currentNode -> transactionObject -> transactionType << endl;
         cout << "  Channel   : " << currentNode -> transactionObject -> paymentChannel << endl;
         cout << "  Timestamp : " << currentNode -> transactionObject -> timestamp << endl;
+        cout << "  Location  : " << currentNode -> transactionObject -> location << endl;
         cout << "-----------------------------" << endl;
 
         // Move to the next node

--- a/src/entities/DoublyLinkedList.cpp
+++ b/src/entities/DoublyLinkedList.cpp
@@ -12,13 +12,13 @@ using namespace std;
  * @param data The pointer to the Transaction object
  * @param index The current size of the linked list. This acts as the index for the node (since no deletion is involved).
  */
-Node::Node(const Transaction* data, const int index) {
+Node::Node(Transaction* data, const int index) {
 
     // First check if a valid object is passed into the method
     if (data == nullptr) throw invalid_argument("Data cannot be null.");
 
     // Initialize variables
-    this -> transactionObject = const_cast<Transaction*>(data);
+    this -> transactionObject = data;
     this -> previousNode = nullptr;
     this -> nextNode = nullptr;
     this -> indexInList = index;
@@ -98,7 +98,7 @@ void DoublyLinkedList::setTailNode(Node* tailNode) {
  * @param node The node that will be placed after the new node
  * @param data The Transaction object
  */
-void DoublyLinkedList::insertBefore(Node* node, const Transaction* data) {
+void DoublyLinkedList::insertBefore(Node* node, Transaction* data) {
 
     // Overall idea: Three nodes have to be set up. The specified node, the previous node of the specified node, and the new node.
 
@@ -137,7 +137,7 @@ void DoublyLinkedList::insertBefore(Node* node, const Transaction* data) {
  * The method to insert the Transaction object into the end of linked list.
  * @param data The Transaction object to be added.
  */
-void DoublyLinkedList::insertAtEnd(const Transaction* data) {
+void DoublyLinkedList::insertAtEnd(Transaction* data) {
 
     // First create a node for the data
     const auto newNode = new Node(data, ++size);

--- a/src/entities/DoublyLinkedList.cpp
+++ b/src/entities/DoublyLinkedList.cpp
@@ -18,7 +18,7 @@ Node::Node(const Transaction* data, const int index) {
     if (data == nullptr) throw invalid_argument("Data cannot be null.");
 
     // Initialize variables
-    this -> transactionObject = const_cast<Transaction*>(data);
+    this -> transactionObject = data;
     this -> previousNode = nullptr;
     this -> nextNode = nullptr;
     this -> indexInList = index;

--- a/src/entities/DoublyLinkedList.h
+++ b/src/entities/DoublyLinkedList.h
@@ -12,7 +12,7 @@
 struct Node {
 
     // A doubly linked list has three elements: data, pointer of previous and next node
-    Transaction* transactionObject;
+    const Transaction* transactionObject;
     int indexInList;
     Node* previousNode;
     Node* nextNode;

--- a/src/entities/DoublyLinkedList.h
+++ b/src/entities/DoublyLinkedList.h
@@ -12,7 +12,7 @@
 struct Node {
 
     // A doubly linked list has three elements: data, pointer of previous and next node
-    Transaction transactionObject;
+    Transaction* transactionObject;
     int indexInList;
     Node* previousNode;
     Node* nextNode;

--- a/src/entities/DoublyLinkedList.h
+++ b/src/entities/DoublyLinkedList.h
@@ -18,7 +18,7 @@ struct Node {
     Node* nextNode;
 
     // Constructor: Explicit to ensure no implicit conversions take place
-    explicit Node(const Transaction* data, int index);
+    explicit Node(Transaction* data, int index);
 };
 
 /**
@@ -47,8 +47,8 @@ public:
     void setTailNode(Node* tailNode);
 
     // Insertion methods
-    void insertBefore(Node* node, const Transaction* data);
-    void insertAtEnd(const Transaction* data);
+    void insertBefore(Node* node, Transaction* data);
+    void insertAtEnd(Transaction* data);
 
     // Print contents
     void printContents() const;

--- a/src/entities/DoublyLinkedList.h
+++ b/src/entities/DoublyLinkedList.h
@@ -18,7 +18,7 @@ struct Node {
     Node* nextNode;
 
     // Constructor: Explicit to ensure no implicit conversions take place
-    explicit Node(Transaction* data, int index);
+    explicit Node(const Transaction* data, int index);
 };
 
 /**
@@ -47,8 +47,8 @@ public:
     void setTailNode(Node* tailNode);
 
     // Insertion methods
-    void insertBefore(Node* node, Transaction* data);
-    void insertAtEnd(Transaction* data);
+    void insertBefore(Node* node, const Transaction* data);
+    void insertAtEnd(const Transaction* data);
 
     // Print contents
     void printContents() const;

--- a/src/entities/DoublyLinkedList.h
+++ b/src/entities/DoublyLinkedList.h
@@ -12,7 +12,7 @@
 struct Node {
 
     // A doubly linked list has three elements: data, pointer of previous and next node
-    const Transaction* transactionObject;
+    Transaction* transactionObject;
     int indexInList;
     Node* previousNode;
     Node* nextNode;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -681,7 +681,7 @@ PerformanceTracker* listBubbleSort(DoublyLinkedList &list, const string &searchT
         while (node != nullptr && i < SAMPLING_SIZE) {
 
             // Create a copy of the transaction object and insert to the list
-            const Transaction* transactionObject = node -> transactionObject;
+            Transaction* transactionObject = node -> transactionObject;
             tempList -> insertAtEnd(transactionObject);
 
             // Traverse to the next node
@@ -739,7 +739,7 @@ PerformanceTracker* listInsertionSort(DoublyLinkedList &list, const string &sear
         while (node != nullptr && i < SAMPLING_SIZE) {
 
             // Create a copy of the transaction object and insert to the list
-            const Transaction* transactionObject = node -> transactionObject;
+            Transaction* transactionObject = node -> transactionObject;
             tempList -> insertAtEnd(transactionObject);
 
             // Traverse to the next node
@@ -797,7 +797,7 @@ PerformanceTracker* listMergeSort(DoublyLinkedList &list, const string &searchTy
         while (node != nullptr && i < SAMPLING_SIZE) {
 
             // Create a copy of the transaction object and insert to the list
-            const Transaction* transactionObject = node -> transactionObject;
+            Transaction* transactionObject = node -> transactionObject;
             tempList -> insertAtEnd(transactionObject);
 
             // Traverse to the next node
@@ -855,7 +855,7 @@ PerformanceTracker* listQuickSort(DoublyLinkedList &list, const string &searchTy
         while (node != nullptr && i < SAMPLING_SIZE) {
 
             // Create a copy of the transaction object and insert to the list
-            const Transaction* transactionObject = node -> transactionObject;
+            Transaction* transactionObject = node -> transactionObject;
             tempList -> insertAtEnd(transactionObject);
 
             // Traverse to the next node

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -481,7 +481,7 @@ PerformanceTracker* arrayBubbleSort(Transaction* &array, int &size, const string
     bool shouldCopyBack = false;
 
     // If sampling is needed, we sample for 100 records
-    if (sample) {
+    if (sample && SAMPLING_SIZE < size) {
 
         // Create a new array and copy the first 100 data into it
         workingArray = new Transaction[SAMPLING_SIZE];
@@ -528,7 +528,7 @@ PerformanceTracker* arrayInsertionSort(Transaction* &array, int &size, const str
     bool shouldCopyBack = false;
 
     // If sampling is needed, we sample for 100 records
-    if (sample) {
+    if (sample && SAMPLING_SIZE < size) {
 
         // Create a new array and copy the first 100 data into it
         workingArray = new Transaction[SAMPLING_SIZE];
@@ -575,7 +575,7 @@ PerformanceTracker* arrayMergeSort(Transaction* &array, int &size, const string 
     bool shouldCopyBack = false;
 
     // If sampling is needed, we sample for 100 records
-    if (sample) {
+    if (sample && SAMPLING_SIZE < size) {
 
         // Create a new array and copy the first 100 data into it
         workingArray = new Transaction[SAMPLING_SIZE];
@@ -622,7 +622,7 @@ PerformanceTracker* arrayQuickSort(Transaction* &array, int &size, const string 
     bool shouldCopyBack = false;
 
     // If sampling is needed, we sample for 100 records
-    if (sample) {
+    if (sample && SAMPLING_SIZE < size) {
 
         // Create a new array and copy the first 100 data into it
         workingArray = new Transaction[SAMPLING_SIZE];
@@ -668,7 +668,7 @@ PerformanceTracker* listBubbleSort(DoublyLinkedList &list, const string &searchT
     DoublyLinkedList* tempList = nullptr;
 
     // If sampling is required, create a new list
-    if (sample) {
+    if (sample && SAMPLING_SIZE < list.getSize()) {
 
         // The temporary list created to store nodes
         tempList = new DoublyLinkedList();
@@ -726,7 +726,7 @@ PerformanceTracker* listInsertionSort(DoublyLinkedList &list, const string &sear
     DoublyLinkedList* tempList = nullptr;
 
     // If sampling is required, create a new list
-    if (sample) {
+    if (sample && SAMPLING_SIZE < list.getSize()) {
 
         // The temporary list created to store nodes
         tempList = new DoublyLinkedList();
@@ -784,7 +784,7 @@ PerformanceTracker* listMergeSort(DoublyLinkedList &list, const string &searchTy
     DoublyLinkedList* tempList = nullptr;
 
     // If sampling is required, create a new list
-    if (sample) {
+    if (sample && SAMPLING_SIZE < list.getSize()) {
 
         // The temporary list created to store nodes
         tempList = new DoublyLinkedList();
@@ -842,7 +842,7 @@ PerformanceTracker* listQuickSort(DoublyLinkedList &list, const string &searchTy
     DoublyLinkedList* tempList = nullptr;
 
     // If sampling is required, create a new list
-    if (sample) {
+    if (sample && SAMPLING_SIZE < list.getSize()) {
 
         // The temporary list created to store nodes
         tempList = new DoublyLinkedList();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -681,7 +681,7 @@ PerformanceTracker* listBubbleSort(DoublyLinkedList &list, const string &searchT
         while (node != nullptr && i < SAMPLING_SIZE) {
 
             // Create a copy of the transaction object and insert to the list
-            Transaction* transactionObject = node -> transactionObject;
+            const Transaction* transactionObject = node -> transactionObject;
             tempList -> insertAtEnd(transactionObject);
 
             // Traverse to the next node
@@ -739,7 +739,7 @@ PerformanceTracker* listInsertionSort(DoublyLinkedList &list, const string &sear
         while (node != nullptr && i < SAMPLING_SIZE) {
 
             // Create a copy of the transaction object and insert to the list
-            Transaction* transactionObject = node -> transactionObject;
+            const Transaction* transactionObject = node -> transactionObject;
             tempList -> insertAtEnd(transactionObject);
 
             // Traverse to the next node
@@ -797,7 +797,7 @@ PerformanceTracker* listMergeSort(DoublyLinkedList &list, const string &searchTy
         while (node != nullptr && i < SAMPLING_SIZE) {
 
             // Create a copy of the transaction object and insert to the list
-            Transaction* transactionObject = node -> transactionObject;
+            const Transaction* transactionObject = node -> transactionObject;
             tempList -> insertAtEnd(transactionObject);
 
             // Traverse to the next node
@@ -855,7 +855,7 @@ PerformanceTracker* listQuickSort(DoublyLinkedList &list, const string &searchTy
         while (node != nullptr && i < SAMPLING_SIZE) {
 
             // Create a copy of the transaction object and insert to the list
-            Transaction* transactionObject = node -> transactionObject;
+            const Transaction* transactionObject = node -> transactionObject;
             tempList -> insertAtEnd(transactionObject);
 
             // Traverse to the next node

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -83,7 +83,7 @@ int main() {
     // Task 1: Separate data based on different channels.
     // Goal: Compare performance of the normal read and write between arrays and linked lists
     cout << "--------Task 1: Separate data into different channels--------" << endl;
-    cout << endl << "Separating data from the overall array ... " << endl;
+    cout << "\nSeparating data from the overall array ... " << endl;
 
     // Array
     Transaction *achArray = nullptr, *cardArray = nullptr, *upiArray = nullptr, *wireTransferArray = nullptr;
@@ -142,47 +142,58 @@ int main() {
     int mergeSortSize = totalArrayRow;
     int quickSortSize = totalArrayRow;
 
+    // Copy array for merge sort
     copyArray(overallTransactionArray, totalArrayRow, locationMergeSortArray);
-    copyArray(overallTransactionArray, totalArrayRow, locationQuickSortArray);
 
     cout << endl << "Sorting data from array using merge sort ... " << endl;
     tracker = arrayMergeSort(locationMergeSortArray, mergeSortSize, locationSortKey);
     tracker -> report("Performance for Merge Sort in Array");
     delete tracker;
 
+    cout << "Exporting result to JSON ... " << endl;
+    JsonExport::convertToJson(locationMergeSortArray, mergeSortSize,  "Merge_Sort_Full_Array.json");
+
+    // Release memory after use
+    delete[] locationMergeSortArray;
+
+    // Copy array for quick sort
+    copyArray(overallTransactionArray, totalArrayRow, locationQuickSortArray);
+
     cout << "Sorting data from array using quick sort ... " << endl;
     tracker = arrayQuickSort(locationQuickSortArray, quickSortSize, locationSortKey);
     tracker -> report("Performance for Quick Sort in Array");
     delete tracker;
 
-    cout << "Exporting results to JSON ... " << endl;
-    JsonExport::convertToJson(locationMergeSortArray, mergeSortSize,  "Merge_Sort_Full_Array.json");
+    cout << "Exporting result to JSON ... " << endl;
     JsonExport::convertToJson(locationQuickSortArray, quickSortSize,  "Quick_Sort_Full_Array.json");
 
     // Release memory after use
-    delete[] locationMergeSortArray;
     delete[] locationQuickSortArray;
 
-    // Linked list
+    // Linked list - Merge sort
     auto* mergeSortList = new DoublyLinkedList(*overallTransactionList);
-    auto* quickSortList = new DoublyLinkedList(*overallTransactionList);
-
     cout << endl << "Sorting data from linked list using merge sort ... " << endl;
     tracker = listMergeSort(*mergeSortList, locationSortKey);
     tracker -> report("Performance for Merge Sort in Linked List");
     delete tracker;
 
+    cout << "Exporting result to JSON ... " << endl;
+    JsonExport::convertToJson(mergeSortList, "Merge_Sort_Full_Linked_List.json");
+
+    // Release memory
+    delete mergeSortList;
+
+    // Linked list - Quick sort
+    auto* quickSortList = new DoublyLinkedList(*overallTransactionList);
     cout << "Sorting data from linked list using quick sort ... " << endl;
     tracker = listQuickSort(*quickSortList, locationSortKey);
     tracker -> report("Performance for Quick Sort in Linked List");
     delete tracker;
 
-    cout << "Exporting results to JSON ... " << endl;
-    JsonExport::convertToJson(mergeSortList, "Merge_Sort_Full_Linked_List.json");
+    cout << "Exporting result to JSON ... " << endl;
     JsonExport::convertToJson(quickSortList, "Quick_Sort_Full_Linked_List.json");
 
     // Release memory
-    delete mergeSortList;
     delete quickSortList;
 
     // To compare the performances for all sorting algorithms, the dataset is sampled down.
@@ -200,11 +211,6 @@ int main() {
     copyArray(overallTransactionArray, totalArrayRow, sampledInsertionSortArray);
     copyArray(overallTransactionArray, totalArrayRow, sampledMergeSortArray);
     copyArray(overallTransactionArray, totalArrayRow, sampledQuickSortArray);
-
-    auto* sampledBubbleSortList = new DoublyLinkedList(*overallTransactionList);
-    auto* sampledInsertionSortList = new DoublyLinkedList(*overallTransactionList);
-    auto* sampledMergeSortList = new DoublyLinkedList(*overallTransactionList);
-    auto* sampledQuickSortList = new DoublyLinkedList(*overallTransactionList);
 
     // Sampled-down array
     cout << endl << "Sorting sampled data from array using bubble sort ... " << endl;
@@ -238,6 +244,11 @@ int main() {
     delete[] sampledInsertionSortArray;
     delete[] sampledMergeSortArray;
     delete[] sampledQuickSortArray;
+
+    auto* sampledBubbleSortList = new DoublyLinkedList(*overallTransactionList);
+    auto* sampledInsertionSortList = new DoublyLinkedList(*overallTransactionList);
+    auto* sampledMergeSortList = new DoublyLinkedList(*overallTransactionList);
+    auto* sampledQuickSortList = new DoublyLinkedList(*overallTransactionList);
 
     // Sampled down linked list
     cout << endl << "Sorting sampled data from linked list using bubble sort ... " << endl;
@@ -670,8 +681,8 @@ PerformanceTracker* listBubbleSort(DoublyLinkedList &list, const string &searchT
         while (node != nullptr && i < SAMPLING_SIZE) {
 
             // Create a copy of the transaction object and insert to the list
-            Transaction transactionObject = node -> transactionObject;
-            tempList -> insertAtEnd(&transactionObject);
+            const Transaction* transactionObject = node -> transactionObject;
+            tempList -> insertAtEnd(transactionObject);
 
             // Traverse to the next node
             node = node -> nextNode;
@@ -696,7 +707,7 @@ PerformanceTracker* listBubbleSort(DoublyLinkedList &list, const string &searchT
     list.clear();
     const Node* currentNode = swappedList.getHeadNode();
     while (currentNode != nullptr) {
-        list.insertAtEnd(&currentNode -> transactionObject);
+        list.insertAtEnd(currentNode -> transactionObject);
         currentNode = currentNode -> nextNode;
     }
 
@@ -728,8 +739,8 @@ PerformanceTracker* listInsertionSort(DoublyLinkedList &list, const string &sear
         while (node != nullptr && i < SAMPLING_SIZE) {
 
             // Create a copy of the transaction object and insert to the list
-            Transaction transactionObject = node -> transactionObject;
-            tempList -> insertAtEnd(&transactionObject);
+            const Transaction* transactionObject = node -> transactionObject;
+            tempList -> insertAtEnd(transactionObject);
 
             // Traverse to the next node
             node = node -> nextNode;
@@ -754,7 +765,7 @@ PerformanceTracker* listInsertionSort(DoublyLinkedList &list, const string &sear
     list.clear();
     const Node* currentNode = swappedList.getHeadNode();
     while (currentNode != nullptr) {
-        list.insertAtEnd(&currentNode -> transactionObject);
+        list.insertAtEnd(currentNode -> transactionObject);
         currentNode = currentNode -> nextNode;
     }
 
@@ -786,8 +797,8 @@ PerformanceTracker* listMergeSort(DoublyLinkedList &list, const string &searchTy
         while (node != nullptr && i < SAMPLING_SIZE) {
 
             // Create a copy of the transaction object and insert to the list
-            Transaction transactionObject = node -> transactionObject;
-            tempList -> insertAtEnd(&transactionObject);
+            const Transaction* transactionObject = node -> transactionObject;
+            tempList -> insertAtEnd(transactionObject);
 
             // Traverse to the next node
             node = node -> nextNode;
@@ -812,7 +823,7 @@ PerformanceTracker* listMergeSort(DoublyLinkedList &list, const string &searchTy
     list.clear();
     const Node* currentNode = swappedList.getHeadNode();
     while (currentNode != nullptr) {
-        list.insertAtEnd(&currentNode -> transactionObject);
+        list.insertAtEnd(currentNode -> transactionObject);
         currentNode = currentNode -> nextNode;
     }
 
@@ -844,8 +855,8 @@ PerformanceTracker* listQuickSort(DoublyLinkedList &list, const string &searchTy
         while (node != nullptr && i < SAMPLING_SIZE) {
 
             // Create a copy of the transaction object and insert to the list
-            Transaction transactionObject = node -> transactionObject;
-            tempList -> insertAtEnd(&transactionObject);
+            const Transaction* transactionObject = node -> transactionObject;
+            tempList -> insertAtEnd(transactionObject);
 
             // Traverse to the next node
             node = node -> nextNode;
@@ -870,7 +881,7 @@ PerformanceTracker* listQuickSort(DoublyLinkedList &list, const string &searchTy
     list.clear();
     const Node* currentNode = swappedList.getHeadNode();
     while (currentNode != nullptr) {
-        list.insertAtEnd(&currentNode -> transactionObject);
+        list.insertAtEnd(currentNode -> transactionObject);
         currentNode = currentNode -> nextNode;
     }
 

--- a/src/utilities/ChannelSeparator.cpp
+++ b/src/utilities/ChannelSeparator.cpp
@@ -97,7 +97,7 @@ void ChannelSeparator::splitToChannelList(const DoublyLinkedList* list,
     while (currentNode != nullptr) {
 
         // Retrieve the payment channel
-        const Transaction* currentObject = currentNode -> transactionObject;
+        Transaction* currentObject = currentNode -> transactionObject;
 
         // Check the transaction type and add to the new list
         if (string currentPayment = toLowerCase(currentObject -> paymentChannel);

--- a/src/utilities/ChannelSeparator.cpp
+++ b/src/utilities/ChannelSeparator.cpp
@@ -97,14 +97,14 @@ void ChannelSeparator::splitToChannelList(const DoublyLinkedList* list,
     while (currentNode != nullptr) {
 
         // Retrieve the payment channel
-        Transaction currentObject = currentNode -> transactionObject;
+        const Transaction* currentObject = currentNode -> transactionObject;
 
         // Check the transaction type and add to the new list
-        if (string currentPayment = toLowerCase(currentObject.paymentChannel);
-            currentPayment == "ach")                    achList  -> insertAtEnd(&currentObject);
-        else if (currentPayment == "card")              cardList -> insertAtEnd(&currentObject);
-        else if (currentPayment == "upi")               upiList  -> insertAtEnd(&currentObject);
-        else if (currentPayment == "wire_transfer")     wireList -> insertAtEnd(&currentObject);
+        if (string currentPayment = toLowerCase(currentObject -> paymentChannel);
+                currentPayment == "ach")                    achList -> insertAtEnd(currentObject);
+        else if (currentPayment == "card")                  cardList -> insertAtEnd(currentObject);
+        else if (currentPayment == "upi")                   upiList -> insertAtEnd(currentObject);
+        else if (currentPayment == "wire_transfer")          wireList -> insertAtEnd(currentObject);
 
         // Move on to the next node
         currentNode = currentNode -> nextNode;

--- a/src/utilities/ChannelSeparator.cpp
+++ b/src/utilities/ChannelSeparator.cpp
@@ -97,7 +97,7 @@ void ChannelSeparator::splitToChannelList(const DoublyLinkedList* list,
     while (currentNode != nullptr) {
 
         // Retrieve the payment channel
-        Transaction* currentObject = currentNode -> transactionObject;
+        const Transaction* currentObject = currentNode -> transactionObject;
 
         // Check the transaction type and add to the new list
         if (string currentPayment = toLowerCase(currentObject -> paymentChannel);

--- a/src/utilities/JsonExport.cpp
+++ b/src/utilities/JsonExport.cpp
@@ -238,7 +238,7 @@ void JsonExport::convertToJson(const DoublyLinkedList* list, const string &filen
         while (currentNode != nullptr) {
 
             // Retrieve transaction
-            const Transaction &currentTransaction = currentNode -> transactionObject;
+            const Transaction &currentTransaction = *currentNode -> transactionObject;
 
             // Generate the JSON string for the transaction
             string jsonString = json(currentTransaction).dump(4);

--- a/src/utilities/PerformanceTracker.cpp
+++ b/src/utilities/PerformanceTracker.cpp
@@ -94,7 +94,7 @@ void PerformanceTracker::updatePeakMemory() {
 
         // If memory information can be written, retrieve the peak memory
         if (GetProcessMemoryInfo(GetCurrentProcess(), &pmc, sizeof(pmc))) {
-            peakMemoryUsage = pmc.PeakWorkingSetSize;
+            peakMemoryUsage = pmc.PeakWorkingSetSize / 1024;
         }
 
     // Mac computers can't retrieve peak memory directly.
@@ -114,7 +114,7 @@ void PerformanceTracker::updatePeakMemory() {
             // If yes, retrieve the resident size (current memory usage) to get the peak memory
             size_t currentMemory = t_info.resident_size;
             if (currentMemory > peakMemoryUsage) {
-                peakMemoryUsage = currentMemory;
+                peakMemoryUsage = currentMemory / 1024;
             }
         }
 
@@ -136,12 +136,14 @@ void PerformanceTracker::report(const string &label) const {
 
     // Print performance information
     cout << "\n=== " << label << " ===\n";
-    cout << "Time Taken: " << duration << " ms" << endl;
-    cout << "Peak Memory Usage: " << peakMemoryUsage / 1024 << " KB" << endl;
-    cout << "Beginning memory: " << beginningMemory << " KB" << endl;
-    cout << "Final memory: " << finalMemory << " KB" << endl;
+    cout << "Time Taken: " << duration << " ms (" << duration / 1000 << " seconds)" << endl;
+    cout << "Beginning memory: " << beginningMemory << " KB (" << beginningMemory / 1024 << " MB)" << endl;
+    cout << "Final memory: " << finalMemory << " KB (" << finalMemory / 1024 << " MB)" << endl;
     cout << "Difference between Beginning and Final Memory Usage: " <<
         (finalMemory > beginningMemory ? finalMemory - beginningMemory : beginningMemory - finalMemory) <<
-            " KB" << endl;
+            " KB (" <<
+        (finalMemory > beginningMemory ? finalMemory - beginningMemory : beginningMemory - finalMemory) / 1024 <<
+            " MB)" << endl;
+    cout << "Peak Memory Usage: " << peakMemoryUsage << " KB (" << peakMemoryUsage / 1024 << " MB)" << endl;
     cout << endl;
 }

--- a/src/utilities/Searcher.cpp
+++ b/src/utilities/Searcher.cpp
@@ -78,14 +78,14 @@ Transaction** Searcher::linearSearchUsingList(const DoublyLinkedList &list, stri
     while (currentNode != nullptr) {
 
         // Get the lower case version of the transaction type for each node
-        string nodeTransactionType = currentNode -> transactionObject.transactionType;
+        string nodeTransactionType = currentNode -> transactionObject -> transactionType;
         nodeTransactionType = toLowerCase(nodeTransactionType);
 
         // Check if the current node matches condition
         if (nodeTransactionType == transactionType) {
 
             // Add the transaction object to the array
-            result[matchCount] = &currentNode -> transactionObject;
+            result[matchCount] = currentNode -> transactionObject;
 
             // Increment match count for the next iteration
             matchCount++;
@@ -231,13 +231,13 @@ Transaction** Searcher::binarySearchUsingList(const DoublyLinkedList &list, stri
         if (leftNode == rightNode || leftNode -> nextNode == rightNode) {
 
             // First retrieve the strings and convert them to lower case
-            string leftNodeTransactionType = leftNode -> transactionObject.transactionType;
+            string leftNodeTransactionType = leftNode -> transactionObject -> transactionType;
             string rightNodeTransactionType;
             toLowerCase(leftNodeTransactionType);
 
             // Don't repeat the same process if two nodes are the same
             if (leftNode != rightNode) {
-                rightNodeTransactionType = rightNode -> transactionObject.transactionType;
+                rightNodeTransactionType = rightNode -> transactionObject -> transactionType;
                 toLowerCase(rightNodeTransactionType);
             }
 
@@ -249,7 +249,7 @@ Transaction** Searcher::binarySearchUsingList(const DoublyLinkedList &list, stri
             if (leftNodeTransactionType == transactionType) {
 
                 // Add the result to the first index
-                result[0] = &leftNode -> transactionObject;
+                result[0] = leftNode -> transactionObject;
                 indexZeroTaken = true;
                 listSize++;
             }
@@ -259,7 +259,7 @@ Transaction** Searcher::binarySearchUsingList(const DoublyLinkedList &list, stri
 
                 // Get the index for the position to fill and insert the object if match
                 const int indexToFill = indexZeroTaken ? 1 : 0;
-                result[indexToFill] = &rightNode -> transactionObject;
+                result[indexToFill] = rightNode -> transactionObject;
                 listSize++;
             }
 
@@ -275,7 +275,7 @@ Transaction** Searcher::binarySearchUsingList(const DoublyLinkedList &list, stri
         if (middleNode == nullptr) return nullptr;
 
         // If not, we retrieve the transaction type for the middle node
-        string retrievedType = middleNode -> transactionObject.transactionType;
+        string retrievedType = middleNode -> transactionObject -> transactionType;
 
         // Now convert the associated transaction type to lower case
         toLowerCase(retrievedType);
@@ -296,7 +296,7 @@ Transaction** Searcher::binarySearchUsingList(const DoublyLinkedList &list, stri
         if (retrievedType == transactionType) {
 
             // First place the transaction object associated with the middle node into the list
-            result[0] = &middleNode -> transactionObject;
+            result[0] = middleNode -> transactionObject;
 
             // Create a counter to record the index
             int index = 1;
@@ -309,10 +309,10 @@ Transaction** Searcher::binarySearchUsingList(const DoublyLinkedList &list, stri
             while (traverseToFront != nullptr) {
 
                 // Since the linked list is already sorted, the loop ends once the transaction type does not match
-                if (traverseToFront -> transactionObject.transactionType != retrievedType) break;
+                if (traverseToFront -> transactionObject -> transactionType != retrievedType) break;
 
                 // If it matches, store the objects into the result list
-                result[index] = &traverseToFront -> transactionObject;
+                result[index] = traverseToFront -> transactionObject;
 
                 // Move to the previous one
                 traverseToFront = traverseToFront -> previousNode;
@@ -323,10 +323,10 @@ Transaction** Searcher::binarySearchUsingList(const DoublyLinkedList &list, stri
             while (traverseToBack != nullptr) {
 
                 // End once the transaction type does not tally
-                if (traverseToBack -> transactionObject.transactionType != retrievedType) break;
+                if (traverseToBack -> transactionObject -> transactionType != retrievedType) break;
 
                 // If it matches, store the objects into the result list
-                result[index] = &traverseToBack -> transactionObject;
+                result[index] = traverseToBack -> transactionObject;
 
                 // Move to the previous one
                 traverseToBack = traverseToBack -> nextNode;

--- a/src/utilities/Sorter.cpp
+++ b/src/utilities/Sorter.cpp
@@ -102,19 +102,19 @@ DoublyLinkedList Sorter::bubbleSortInList(const DoublyLinkedList &list, const st
             Node* rightNode = currentNode -> nextNode;
 
             // Get the information from the two nodes
-            const string leftID = leftNode -> transactionObject.transactionId;
-            const string rightID = rightNode -> transactionObject.transactionId;
+            const string leftID = leftNode -> transactionObject -> transactionId;
+            const string rightID = rightNode -> transactionObject -> transactionId;
             string leftData, rightData;
 
             // If sort is performed based on the location
             if (sortingVar == "location") {
-                leftData = toLowerCase(leftNode -> transactionObject.location);
-                rightData = toLowerCase(rightNode -> transactionObject.location);
+                leftData = toLowerCase(leftNode -> transactionObject -> location);
+                rightData = toLowerCase(rightNode -> transactionObject -> location);
 
             // If sort is performed based on the transaction type
             } else if (sortingVar == "type") {
-                leftData = toLowerCase(leftNode -> transactionObject.transactionType);
-                rightData = toLowerCase(rightNode -> transactionObject.transactionType);
+                leftData = toLowerCase(leftNode -> transactionObject -> transactionType);
+                rightData = toLowerCase(rightNode -> transactionObject -> transactionType);
 
             // Other cases
             } else {
@@ -233,17 +233,17 @@ DoublyLinkedList Sorter::insertionSortInList(const DoublyLinkedList &list, const
     while (currentNode != nullptr) {
 
         // Retrieve the transaction ID and type of the object for the current node
-        Transaction currentObject = currentNode -> transactionObject;
-        string currentID = currentObject.transactionId;
+        const Transaction* currentObject = currentNode -> transactionObject;
+        string currentID = currentObject -> transactionId;
         string currentData;
 
         // If sort is performed based on the location
         if (sortingVar == "location") {
-            currentData = toLowerCase(currentObject.location);
+            currentData = toLowerCase(currentObject -> location);
 
         // If sort is performed based on the transaction type
         } else if (sortingVar == "type") {
-            currentData = toLowerCase(currentObject.transactionType);
+            currentData = toLowerCase(currentObject -> transactionType);
 
         // Other cases
         } else {
@@ -254,7 +254,7 @@ DoublyLinkedList Sorter::insertionSortInList(const DoublyLinkedList &list, const
         if (sortedList -> isEmpty()) {
 
             // Insert the transaction object to the node and go to the next iteration
-            sortedList -> insertAtEnd(&currentObject);
+            sortedList -> insertAtEnd(currentObject);
             currentNode = currentNode -> nextNode;
             continue;
         }
@@ -268,16 +268,16 @@ DoublyLinkedList Sorter::insertionSortInList(const DoublyLinkedList &list, const
         while (currentSortedNode != nullptr) {
 
             // Retrieve the information of the current node in the sorted list
-            string currentSortedID = currentSortedNode -> transactionObject.transactionId;
+            string currentSortedID = currentSortedNode -> transactionObject -> transactionId;
             string currentSortedData;
 
             // If sort is performed based on the location
             if (sortingVar == "location") {
-                currentSortedData = toLowerCase(currentSortedNode -> transactionObject.location);
+                currentSortedData = toLowerCase(currentSortedNode -> transactionObject -> location);
 
             // If sort is performed based on the transaction type
             } else if (sortingVar == "type") {
-                currentSortedData = toLowerCase(currentSortedNode -> transactionObject.transactionType);
+                currentSortedData = toLowerCase(currentSortedNode -> transactionObject -> transactionType);
 
             // Other cases
             } else {
@@ -290,13 +290,13 @@ DoublyLinkedList Sorter::insertionSortInList(const DoublyLinkedList &list, const
 
                 // Insert the node after this sorted node, i.e., before the next sorted node if there is a next
                 if (currentSortedNode -> nextNode != nullptr) {
-                    sortedList -> insertBefore(currentSortedNode -> nextNode, &currentObject);
+                    sortedList -> insertBefore(currentSortedNode -> nextNode, currentObject);
 
                 // If the sorted node is no next, the node is a tail
                 } else {
 
                     // Add the node as a tail
-                    sortedList -> insertAtEnd(&currentObject);
+                    sortedList -> insertAtEnd(currentObject);
                 }
 
                 // Mark that an insertion has taken place, hence loop exits
@@ -309,7 +309,7 @@ DoublyLinkedList Sorter::insertionSortInList(const DoublyLinkedList &list, const
         }
 
         // If the node is not inserted, insert at the beginning
-        if (!inserted) sortedList->insertBefore(sortedList -> getHeadNode(), &currentObject);
+        if (!inserted) sortedList->insertBefore(sortedList -> getHeadNode(), currentObject);
 
         // Move to the next node
         currentNode = currentNode -> nextNode;
@@ -566,8 +566,8 @@ Node* Sorter::mergeNodesForList(Node* nodeInLeft, Node* nodeInRight, const strin
     while (nodeInLeft != nullptr && nodeInRight != nullptr) {
 
         // Retrieve the objects in the first of both parts
-        Transaction &leftObject = nodeInLeft -> transactionObject;
-        Transaction &rightObject = nodeInRight -> transactionObject;
+        const Transaction* leftObject = nodeInLeft -> transactionObject;
+        const Transaction* rightObject = nodeInRight -> transactionObject;
 
         // Declare a boolean to mark our choice
         bool chooseLeft = false;
@@ -577,13 +577,13 @@ Node* Sorter::mergeNodesForList(Node* nodeInLeft, Node* nodeInRight, const strin
 
         // If sort is performed based on the location
         if (sortingVar == "location") {
-            leftData = toLowerCase(leftObject.location);
-            rightData = toLowerCase(rightObject.location);
+            leftData = toLowerCase(leftObject -> location);
+            rightData = toLowerCase(rightObject -> location);
 
         // If sort is performed based on the transaction type
         } else if (sortingVar == "type") {
-            leftData = toLowerCase(leftObject.transactionType);
-            rightData = toLowerCase(rightObject.transactionType);
+            leftData = toLowerCase(leftObject -> transactionType);
+            rightData = toLowerCase(rightObject -> transactionType);
 
         // Other cases
         } else {
@@ -598,7 +598,7 @@ Node* Sorter::mergeNodesForList(Node* nodeInLeft, Node* nodeInRight, const strin
         } else if (leftData == rightData) {
 
             // We compare ID. Choose left if the left ID is smaller
-            chooseLeft = leftObject.transactionId < rightObject.transactionId;
+            chooseLeft = leftObject -> transactionId < rightObject -> transactionId;
         }
 
         // Retrieve the selected node
@@ -819,7 +819,7 @@ DoublyLinkedList Sorter::quickSortInList(const DoublyLinkedList &list, const str
     while (currentNode != nullptr) {
 
         // Create new nodes
-        auto* newNode = new Node(&currentNode -> transactionObject, currentNode -> indexInList);
+        auto* newNode = new Node(currentNode -> transactionObject, currentNode -> indexInList);
 
         // Check if the node is a head node
         if (copiedHead == nullptr || lastCopied == nullptr) copiedHead = newNode;
@@ -955,17 +955,17 @@ Node* Sorter::quickSortPartitionForList(Node* head, Node* tail, Node** leftNodes
     Node* middle = getMiddleNodeForList(head);
 
     // Retrieve the data from all three nodes
-    string headData = sortingVar == "location" ? toLowerCase(head -> transactionObject.location) :
-                                                 toLowerCase(head -> transactionObject.transactionType);
-    string headID = head -> transactionObject.transactionId;
+    string headData = sortingVar == "location" ? toLowerCase(head -> transactionObject -> location) :
+                                                 toLowerCase(head -> transactionObject -> transactionType);
+    string headID = head -> transactionObject -> transactionId;
 
-    string middleData = sortingVar == "location" ? toLowerCase(middle -> transactionObject.location) :
-                                                   toLowerCase(middle -> transactionObject.transactionType);
-    string middleID = middle -> transactionObject.transactionId;
+    string middleData = sortingVar == "location" ? toLowerCase(middle -> transactionObject -> location) :
+                                                   toLowerCase(middle -> transactionObject -> transactionType);
+    string middleID = middle -> transactionObject -> transactionId;
 
-    string tailData = sortingVar == "location" ? toLowerCase(tail -> transactionObject.location) :
-                                                 toLowerCase(tail -> transactionObject.transactionType);
-    string tailID = tail -> transactionObject.transactionId;
+    string tailData = sortingVar == "location" ? toLowerCase(tail -> transactionObject -> location) :
+                                                 toLowerCase(tail -> transactionObject -> transactionType);
+    string tailID = tail -> transactionObject -> transactionId;
 
     // Choosing the median. We first assume the tail is the node
     Node* pivot = tail;
@@ -988,9 +988,9 @@ Node* Sorter::quickSortPartitionForList(Node* head, Node* tail, Node** leftNodes
     // Other conditions: Do nothing, the tail is already the pivot
 
     // We can now get the pivot's data for later comparison
-    string pivotData = sortingVar == "location" ? toLowerCase(pivot -> transactionObject.location) :
-                                                  toLowerCase(pivot -> transactionObject.transactionType);
-    string pivotID = pivot -> transactionObject.transactionId;
+    string pivotData = sortingVar == "location" ? toLowerCase(pivot -> transactionObject -> location) :
+                                                  toLowerCase(pivot -> transactionObject -> transactionType);
+    string pivotID = pivot -> transactionObject -> transactionId;
 
     // Initialize the nodes for left and right partitions
     Node* leftHead = nullptr;
@@ -1012,9 +1012,9 @@ Node* Sorter::quickSortPartitionForList(Node* head, Node* tail, Node** leftNodes
         }
 
         // Get the data for the current node
-        string currData = sortingVar == "location" ? toLowerCase(currentNode -> transactionObject.location) :
-                                                     toLowerCase(currentNode -> transactionObject.transactionType);
-        string currID = currentNode -> transactionObject.transactionId;
+        string currData = sortingVar == "location" ? toLowerCase(currentNode -> transactionObject -> location) :
+                                                     toLowerCase(currentNode -> transactionObject -> transactionType);
+        string currID = currentNode -> transactionObject -> transactionId;
 
         // First, disconnect the current node
         currentNode -> nextNode = nullptr;

--- a/src/utilities/Sorter.cpp
+++ b/src/utilities/Sorter.cpp
@@ -233,7 +233,7 @@ DoublyLinkedList Sorter::insertionSortInList(const DoublyLinkedList &list, const
     while (currentNode != nullptr) {
 
         // Retrieve the transaction ID and type of the object for the current node
-        Transaction* currentObject = currentNode -> transactionObject;
+        const Transaction* currentObject = currentNode -> transactionObject;
         string currentID = currentObject -> transactionId;
         string currentData;
 

--- a/src/utilities/Sorter.cpp
+++ b/src/utilities/Sorter.cpp
@@ -233,7 +233,7 @@ DoublyLinkedList Sorter::insertionSortInList(const DoublyLinkedList &list, const
     while (currentNode != nullptr) {
 
         // Retrieve the transaction ID and type of the object for the current node
-        const Transaction* currentObject = currentNode -> transactionObject;
+        Transaction* currentObject = currentNode -> transactionObject;
         string currentID = currentObject -> transactionId;
         string currentData;
 

--- a/src/utilities/TransactionReader.cpp
+++ b/src/utilities/TransactionReader.cpp
@@ -173,7 +173,7 @@ void TransactionReader::readCSVToList(const string& filename, DoublyLinkedList* 
         if (Transaction transaction; parseLineToTransaction(line, transaction)) {
 
             // The transaction object is copied so that it can still remain for the later iterations
-            auto* transactionTemp = new Transaction(transaction);
+            const auto* transactionTemp = new Transaction(transaction);
             list -> insertAtEnd(transactionTemp);
 
         // Error message printed if unsuccessful

--- a/src/utilities/TransactionReader.cpp
+++ b/src/utilities/TransactionReader.cpp
@@ -173,7 +173,7 @@ void TransactionReader::readCSVToList(const string& filename, DoublyLinkedList* 
         if (Transaction transaction; parseLineToTransaction(line, transaction)) {
 
             // The transaction object is copied so that it can still remain for the later iterations
-            const auto* transactionTemp = new Transaction(transaction);
+            auto* transactionTemp = new Transaction(transaction);
             list -> insertAtEnd(transactionTemp);
 
         // Error message printed if unsuccessful


### PR DESCRIPTION
Changed the ```Transaction``` object in linked list to ```Transaction*```pointer for better performance.
Update the function in ```main``` to avoid duplicate local copy.
Rearrange some of the ```copyArray```or linked list to increase fairness for comparison. 

I got a more reasonable results (like beginning for current process is similar to previous final) and slightly increase the performance for linked list (on my side at least).

Do take a look when you are free, @BengRhui . I not neijuan ah, I slept early and just wake up.🫡🫡 

For the documentation, I will be able to complete it on Sunday but at most on Monday. Cuz need some modification on what I have written.